### PR TITLE
Fix: Stories carousel width

### DIFF
--- a/src/lib/components/core/carousel.svelte
+++ b/src/lib/components/core/carousel.svelte
@@ -89,7 +89,8 @@ input[type=radio] {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     padding: var(--space-md) 0;
-    width: 24em;
+    width: 100%;
+    max-width: 22em;
     box-sizing: border-box;
 }
     
@@ -105,7 +106,7 @@ input[type=radio] {
     .story-list {
         grid-template-columns: repeat(2, 1fr);
         grid-template-rows: repeat(4, auto);
-        width: 48em;
+        max-width: 44em;
     }
 }
 

--- a/src/lib/components/core/carousel.svelte
+++ b/src/lib/components/core/carousel.svelte
@@ -90,7 +90,7 @@ input[type=radio] {
     scroll-snap-type: x mandatory;
     padding: var(--space-md) 0;
     width: 100%;
-    max-width: 22em;
+    max-width: 23em;
     box-sizing: border-box;
 }
     


### PR DESCRIPTION
## What does this change?

closes #258

This PR fixes the width of the stories carousel. Before it had a horizontal scroll and a white border

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

### before:


![Image](https://github.com/user-attachments/assets/ce69241a-5e2f-4359-a6e5-bbe1ecc9683e)

### after:

![image](https://github.com/user-attachments/assets/ff9918b5-c8e8-443a-9e31-7efee8a6d501)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- verify if the horizontal scroll is gone
- if white border is gone
