### PR TITLE
feat: added sign-up functionality to register the data #101

### DIFF
--- a/src/lib/components/forms/input.svelte
+++ b/src/lib/components/forms/input.svelte
@@ -12,7 +12,6 @@
   {:else if type === 'password'}
     Password
   {:else}
-    {name}
     Name
   {/if}
 </label>

--- a/src/lib/components/forms/input.svelte
+++ b/src/lib/components/forms/input.svelte
@@ -13,6 +13,7 @@
     Password
   {:else}
     {name}
+    Name
   {/if}
 </label>
 

--- a/src/routes/sign-up/+page.server.js
+++ b/src/routes/sign-up/+page.server.js
@@ -1,0 +1,39 @@
+import { fail, redirect } from '@sveltejs/kit';
+import argon2 from 'argon2';
+import getDirectusInstance from '$lib/directus';
+import { createItem } from '@directus/sdk';
+
+export const actions = {
+  default: async ({ request, fetch }) => {
+    const formData = await request.formData();
+    const name = formData.get('name')?.toString().trim();
+    const email = formData.get('email')?.toString().trim();
+    const password = formData.get('password')?.toString();
+
+    const directus = getDirectusInstance(fetch);
+
+    /** hier wordt het wachtwoord gehasht met argon2, zodat de wachtwoord beveiligd in de database staat */
+    let hashedPassword;
+    try {
+      hashedPassword = await argon2.hash(password);
+    } catch (err) {
+      return fail(500, { err });
+    }
+
+    // De nieuwe gebruiker wordt hiermee toegevoegd aan directus
+    try {
+      await directus.request(
+        createItem('tm_users', {
+          name,
+          email,
+          password: hashedPassword
+        })
+      );
+    } catch (err) {
+      return fail(500, { err });
+    }
+
+    /** als de gebruiker is toegevoegd aan de database, wordt de gebruiker omgeleid naar de choose-buddy pagina om verder te gaan met de registratie */
+    throw redirect(303, '/choose-buddy');
+  }
+};

--- a/src/routes/sign-up/+page.server.js
+++ b/src/routes/sign-up/+page.server.js
@@ -6,9 +6,9 @@ import { createItem } from '@directus/sdk';
 export const actions = {
   default: async ({ request, fetch }) => {
     const formData = await request.formData();
-    const name = formData.get('name')?.toString().trim();
-    const email = formData.get('email')?.toString().trim();
-    const password = formData.get('password')?.toString();
+    const name = formData.get('name')?.trim();
+    const email = formData.get('email')?.trim();
+    const password = formData.get('password')
 
     const directus = getDirectusInstance(fetch);
 

--- a/src/routes/sign-up/+page.svelte
+++ b/src/routes/sign-up/+page.svelte
@@ -13,10 +13,10 @@ import { Input, Back } from '$lib/index';
             <h1>Sign up</h1> 
         </div>
     
-        <form action="/profile-selection">
-                <Input type="text"/>
-                <Input type="email"/>
-                <Input type="password"/>
+        <form method="POST" action="/sign-up">
+                <Input type="text" name="name" placeholder="Your name"/>
+                <Input type="email" name="email" placeholder="Your email"/>
+                <Input type="password" name="password" placeholder="Your password"/>
 
             <article>
                 <div>

--- a/src/routes/sign-up/+page.svelte
+++ b/src/routes/sign-up/+page.svelte
@@ -14,12 +14,12 @@ import { Input, Back } from '$lib/index';
         </div>
     
         <form method="POST" action="/sign-up">
-                <Input type="text" name="name" placeholder="Your name"/>
-                <Input type="email" name="email" placeholder="Your email"/>
-                <Input type="password" name="password" placeholder="Your password"/>
+                <Input type="text" name="name" placeholder="Enter your full name"/>
+                <Input type="email" name="email" placeholder="email@example.com"/>
+                <Input type="password" name="password" placeholder="Enter your password"/>
 
             <article>
-                <div>
+                <div class="toggle-row">
                     <label class="switch">
                         <input type="checkbox" aria-label="toggle-button">
                         <span class="slider round"></span>
@@ -28,7 +28,7 @@ import { Input, Back } from '$lib/index';
                     <p>Agree to the terms of services and the privacy policy <a href="/click" class="click-here">(click here for more information)</a></p>
                 </div>
         
-                <div>
+                <div class="toggle-row">
                     <label class="switch">
                         <input type="checkbox" aria-label="toggle-button">
                         <span class="slider round"></span>
@@ -115,7 +115,7 @@ div{
 
 /* Styling for toggle button */
 .switch {
-  position: relative;
+  position: absolute;
   display: inline-block;
   width: 5em;
   height: 1.25em;
@@ -126,6 +126,17 @@ div{
   width: 0;
   height: 0;
 }
+
+.toggle-row {
+  position: relative;
+  margin-bottom: 1.25em;
+}
+
+.toggle-row p {
+  margin: 0;
+  margin-left: 3.5em;
+  line-height: 1.4;
+}
 .slider {
   position: absolute;
   cursor: pointer;
@@ -134,7 +145,7 @@ div{
   right: 0;
   bottom: 0;
   width: 2em;
-  background-color: var(--color-white);
+  background-color: grey;
   -webkit-transition: .4s;
   transition: .4s;
 }
@@ -158,7 +169,7 @@ input:focus + .slider {
 input:checked + .slider:before {
   -webkit-transform: translateX(1.25em);
   -ms-transform: translateX(1.25em);
-  transform: translateX(1.25em);
+  transform: translateX(0.80em);
 }
 .slider.round {
   border-radius: 1em;
@@ -179,6 +190,11 @@ input:checked + .slider:before {
     text-decoration: none; 
     margin-top: auto;  
     margin-bottom: 3.75em;
+    cursor: pointer;
+}
+
+.sign-upbtn:hover {
+    background-color: var(--color-login-bg-hover);
 }
 .click-here{
     color: hsla(217, 75%, 65%, 1);


### PR DESCRIPTION
## What does this change?

Resolves issue #101 

Nieuwe gebruikers kunnen nu een account aanmaken door hun gegevens in te vullen. Dit account wordt geregistreerd in de database met een gehashed wachtwoord. Dit zorgt ervoor dat het wachtwoord beveiligd.

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images
**BEFORE**
<img width="471" alt="Scherm­afbeelding 2025-05-07 om 14 34 52" src="https://github.com/user-attachments/assets/d2efebb1-4684-475a-9aa9-f4b8812a309b" />


**AFTER**
<img width="492" alt="Scherm­afbeelding 2025-05-07 om 14 34 28" src="https://github.com/user-attachments/assets/a8b21488-aad8-40af-9874-6acde1182242" />

## How to review
Klik op de knop "sign-up" die je op de home pagina direct kunt zien. Je komt dan op de onboarding pagina die je kunt doorlopen. Tot slot kom je op de registratieformulier. je vult je naam, email en wachtwoord in. Als dit correct wordt ingevuld kom je op de choose-buddy pagina terecht.
