### PR TITLE
View transition for playlist cards/detail page

### DIFF
--- a/src/lib/components/core/MakePlaylist.svelte
+++ b/src/lib/components/core/MakePlaylist.svelte
@@ -156,6 +156,7 @@
     height: 110vh;
     border: none;
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
 }
 .popup__content {
     transform: translate(-50%, -50%);
@@ -172,6 +173,8 @@
     border: none;
     border-radius: var(--border-radius);
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+    z-index: 10000;
+    position: relative;
 }
 li{
     margin-bottom: .2em;

--- a/src/lib/components/core/menu.svelte
+++ b/src/lib/components/core/menu.svelte
@@ -41,6 +41,7 @@
 </header>
 
 <style>
+    
     header {
         height: 5em;
         width: 100%;
@@ -50,6 +51,9 @@
         transform: translate(-50%);
         background-color: #292929;
         color: #fff;
+
+        z-index: 1000;
+        isolation: isolate;
     }
     nav, ul {
         height: 100%;

--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -81,6 +81,11 @@
 
 
 <style>
+  h1 > a {
+  position: relative;
+  isolation: isolate;
+  z-index: 0;
+}
   :root {
     --small-space: .5em;
     --color-text: black;

--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -44,7 +44,11 @@
     <picture>
       <source srcset="{image}?width=128&format=avif" type="image/avif">
       <source srcset="{image}?width=128&format=webp" type="image/webp">
-      <img src="{image}?width=128" alt="{title}">
+      <img
+      src="{image}?width=128"
+      alt="{title}"
+      style="view-transition-name:playlist-image-{playlist.id};"
+      />
     </picture>
   </div>
 

--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -60,7 +60,7 @@
     {title}
   </a>
 
-  <div class="playlist-playtime flex-items">
+  <div class="playlist-playtime flex-items"  style="view-transition-name:playlist-play-{playlist.id};">
     <Play/>
     <p>{playtime}</p>
   </div>

--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -48,9 +48,13 @@
     </picture>
   </div>
 
-  <h3 class="playlist-title">
-    <a href={`/playlist/${playlist.id}`} aria-label="Go to playlist page">{title}</a>
-  </h3>
+  <h3
+  class="playlist-title"
+  style="view-transition-name:playlist-title-{playlist.id};"
+>
+  <a href={`/playlist/${playlist.id}`} aria-label="Go to playlist">
+    {title}
+  </a>
 
   <div class="playlist-playtime flex-items">
     <Play/>
@@ -177,4 +181,20 @@
     animation: scale .5s ease-in;
   }
 
+/* view transition for title */
+::view-transition-old(playlist-title-*),
+::view-transition-new(playlist-title-*) {
+  animation: fade-slide 0.4s ease;
+}
+
+@keyframes fade-slide {
+  from {
+    opacity: 0;
+    transform: translateY(0.5em);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 </style>

--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -75,7 +75,10 @@
         <input type="hidden" name="profileId" value="{profileId}">
       {/if}
       
-      <button type="submit" class="playlist-icons" aria-label="{isLiked ? 'Unlike' : 'Like'}">
+      <button type="submit" 
+        class="playlist-icons" 
+        aria-label="{isLiked ? 'Unlike' : 'Like'}">
+        style="view-transition-name:playlist-like-{playlist.id};"
         <LikeButton {isLiked} />
       </button>
     </form>

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -103,6 +103,7 @@
 
 
 <style>
+
 :root {
     margin: 0;
     padding: 0;

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -85,7 +85,9 @@
     </header>
 
    <section class="meta-section">
-    <h1>{playlist.title}</h1>
+    <h1 style="view-transition-name:playlist-title-{playlist.id};">
+      {playlist.title}
+    </h1>
     <p>{playlist.description}</p>
 
     <div class="meta-info">
@@ -146,7 +148,7 @@
 </main>
 
 <style>
-
+  
 * {
   color: var(--color-text-light);
 }

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -98,7 +98,7 @@
       <p>2u 11m</p>
       </div>
 
-     <div class="meta-play">
+     <div class="meta-play"  style="view-transition-name:playlist-play-{playlist.id};">
         <a href="/download"><img src="/icons/download.svg" alt="download" height="27"></a>
         <button on:click={toggleLike} class="heart-svg" aria-label="{isLiked ? 'Unlike' : 'Like'}">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class:liked={isLiked}>

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -80,6 +80,7 @@
           height="380" 
           width="448" 
           class="playlist-image"
+          style="view-transition-name:playlist-image-{playlist.id};"
         />
       </picture>
     </header>

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -100,10 +100,13 @@
 
      <div class="meta-play"  style="view-transition-name:playlist-play-{playlist.id};">
         <a href="/download"><img src="/icons/download.svg" alt="download" height="27"></a>
-        <button on:click={toggleLike} class="heart-svg" aria-label="{isLiked ? 'Unlike' : 'Like'}">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class:liked={isLiked}>
-            <path d="M11.6536 7.15238C11.8471 7.33832 12.1529 7.33832 12.3464 7.15238C13.1829 6.34871 14.326 5.75 15.6 5.75C18.1489 5.75 20.25 7.64769 20.25 10.0298C20.25 11.7261 19.4577 13.1809 18.348 14.428C17.2397 15.6736 15.7972 16.7316 14.4588 17.6376L12.1401 19.207C12.0555 19.2643 11.9445 19.2643 11.8599 19.207L9.54125 17.6376C8.20278 16.7316 6.76035 15.6736 5.65201 14.428C4.54225 13.1809 3.75 11.7261 3.75 10.0298C3.75 7.64769 5.85106 5.75 8.4 5.75C9.67403 5.75 10.8171 6.34871 11.6536 7.15238Z" stroke="#C4C4C4" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
+        <button on:click={toggleLike} 
+          class="heart-svg" 
+          aria-label="{isLiked ? 'Unlike' : 'Like'}" 
+          style="view-transition-name:playlist-like-{playlist.id};">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class:liked={isLiked}>
+              <path d="M11.6536 7.15238C11.8471 7.33832 12.1529 7.33832 12.3464 7.15238C13.1829 6.34871 14.326 5.75 15.6 5.75C18.1489 5.75 20.25 7.64769 20.25 10.0298C20.25 11.7261 19.4577 13.1809 18.348 14.428C17.2397 15.6736 15.7972 16.7316 14.4588 17.6376L12.1401 19.207C12.0555 19.2643 11.9445 19.2643 11.8599 19.207L9.54125 17.6376C8.20278 16.7316 6.76035 15.6736 5.65201 14.428C4.54225 13.1809 3.75 11.7261 3.75 10.0298C3.75 7.64769 5.85106 5.75 8.4 5.75C9.67403 5.75 10.8171 6.34871 11.6536 7.15238Z" stroke="#C4C4C4" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
         </button>
         <a href="/play"><img src="/icons/play.svg" alt="play" height="60"></a>
     </div>


### PR DESCRIPTION
## What does this change?

Resolves issue #283 , #288 , #291 

This PR adds a view transition between the playlist cards and the playlist detail page.
This includes a smooth animation where the title, like button, play button and playlist image transition to the position of the detail page.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images


https://github.com/user-attachments/assets/beb0f0d2-8bdc-49bb-bd64-31a2a80b074a



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
