### PR TITLE
FEAT: validating registration data in the form with clientside and se…

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-PUBLIC_APIURL = https://fdnd-agency.directus.app
-PUBLIC_TOKEN= OFDr0KIfOvjdCLTiriGxDhSp1LOlWWvr

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@directus/sdk": "17.0.*",
+        "bcryptjs": "^3.0.2",
         "form-data": "^4.0.2",
         "undici": "^7.7.0"
       },
@@ -1300,6 +1301,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/cac": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "dependencies": {
     "@directus/sdk": "17.0.*",
+    "bcryptjs": "^3.0.2",
     "form-data": "^4.0.2",
     "undici": "^7.7.0"
   },

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,12 +6,35 @@ const assetBaseUrl = `${PUBLIC_APIURL}/assets/`;
  
 export async function fetchCollection(fetch, collectionName, id = null) {
     const directus = getDirectusInstance(fetch);
+
+    if (id && typeof id === 'object' && !Array.isArray(id)) {
+        return await directus.request(readItems(collectionName, id));
+    }
  
     if (id) {
         return await directus.request(readItem(collectionName, id));
     }
  
     return await directus.request(readItems(collectionName));
+}
+
+export async function createUser(fetch, userData) {
+    const directus = getDirectusInstance(fetch);
+    try {
+        const newUser = await directus.request(
+        createItem('tm_users', userData)
+    );
+        return {
+            status: 201,
+            data: newUser
+        };
+    } catch (error) {
+        return {
+            status: 500,
+            error: 'User creation failed',
+            details: error.message
+        };
+    }
 }
   
 /**

--- a/src/lib/components/core/Menu.svelte
+++ b/src/lib/components/core/Menu.svelte
@@ -74,13 +74,11 @@ li, li a {
     justify-content: center;
     flex-direction: column;
 }
-.active a svg path, .active a svg rect, .active a svg circle, .active a p {
+.active a p {
     stroke: #599AE7;
     color: #599AE7;
 }
-.active a svg.fill path {
-    fill: #599AE7;
-}
+
 .active a {
     border-bottom: 3px solid #599AE7;
 }

--- a/src/lib/components/forms/Input.svelte
+++ b/src/lib/components/forms/Input.svelte
@@ -3,12 +3,15 @@
   export let placeholder = '';
   export let value = '';
   export let name = '';
-  export let error = '';
+  export let inputClass = '';
+  export let label = '';
 </script>
 
 <label for={name}>
-  {#if type === 'email'}
-    Email
+  {#if label}
+    {label}
+  {:else if type === 'email'}
+  Email
   {:else if type === 'password'}
     Password
   {:else}
@@ -24,7 +27,7 @@
     placeholder={placeholder}
     aria-label={name}
     bind:value={value}
-    required
+    class={inputClass}
   />
 {:else if type === 'password'}
   <input
@@ -34,7 +37,7 @@
     placeholder={placeholder}
     aria-label={name}
     bind:value={value}
-    required
+    class={inputClass}
   />
 {:else}
   <input
@@ -44,12 +47,8 @@
     placeholder={placeholder}
     aria-label={name}
     bind:value={value}
-    required
+    class={inputClass}
   />
-{/if}
-
-{#if error}
-  <span class="error">{error}</span>
 {/if}
 
 <style>
@@ -72,12 +71,10 @@
     padding: 1.5rem 1rem;
     box-sizing: border-box;
   }
-  .error {
-    color: #b60000;
-    font-size: 0.95em;
-    margin-top: -1em;
-    margin-bottom: 1em;
-    display: block;
-    text-align: left;
+  input.is-valid {
+    border: 2px solid #2ecc40;
+  }
+  input.is-invalid {
+    border: 2px solid #d32f2f;
   }
 </style>

--- a/src/lib/components/layout/Playlist.svelte
+++ b/src/lib/components/layout/Playlist.svelte
@@ -126,6 +126,7 @@
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
   }
 
@@ -142,24 +143,11 @@
     font-size: 0.75em;
   }
 
-  .like-button,
   .playlist-icons {
     background: none;
     border: none;
     cursor: pointer;
     padding: 0;
-  }
-
-  .like-button svg.liked,
-  .playlist-icons button svg.liked,
-  .playlist-icons button svg.liked path {
-    fill: #F33232;
-    stroke: #F33232;
-  }
-
-  .like-button svg.liked,
-  .playlist-icons button svg.liked {
-    animation: scale 0.4s ease-in-out;
   }
 
   @keyframes scale {

--- a/src/lib/components/layout/Story.svelte
+++ b/src/lib/components/layout/Story.svelte
@@ -116,6 +116,7 @@ article {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
   font-size: var(--font-size-xs);
 }
@@ -126,20 +127,10 @@ article {
   font-size: var(--font-size-xs);
 }
 
-.story-playtime a svg:hover circle {
-  fill: #F3A22A;
-}
-
 .story-icons {
   grid-area: 3 / 5 / 4 / 6; 
   justify-content: flex-end;
   gap: var(--space-sm);
-}
-
-.story-icons svg:hover path,
-.story-icons svg:hover rect,
-.story-icons svg:hover circle {
-  cursor: pointer;
 }
 
 @media (min-width: 412px) {

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -170,37 +170,9 @@ header {
     justify-content: center;
 }
 
-.playlist-1 > h3 {
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text);
-    margin-bottom: .5em;
-}
-
 .own-playlist {
     display: flex;
     flex-direction: column;
-}
-
-.own-playlist > ul {
-    display: flex;
-    gap: var(--space-sm);
-    overflow-x: auto;
-}
-
-.own-playlist > ul > li {
-    height: 14rem;
-    width: 10em;
-    color: var(--color-text);
-    border-radius: var(--border-radius);
-    padding: .75em;
-    justify-content: center;
-}
-
-.playlist-1 > small {
-    display: flex;
-    gap: .3em;
-    align-items: center;
-    justify-content: center;
 }
 
 /* Styling for "all stories" section & carousel nav */
@@ -223,11 +195,7 @@ nav {
     align-items: center;
     justify-content: center;
 }
-.story-img {
-    width: 100%; 
-    max-width: 100%; 
-    height: auto;
-}
+
 .language-filter {
     display: flex;
     align-items: center;
@@ -278,13 +246,6 @@ label > img {
     background-color: hsla(248, 27%, 36%, 1);
     text-align: center;
     color: var(--color-text-light);
-}
-
-
-
-.playlist-1 > small {
-    align-self: start;
-    margin-top: auto;
 }
 
 /* Styling for suggested playlist page */

--- a/src/routes/log-in/+page.svelte
+++ b/src/routes/log-in/+page.svelte
@@ -193,11 +193,6 @@ a {
     margin-left: auto;
 }
 
-.close-div svg {
-    cursor: pointer;
-    margin-right: -.6em;
-}
-
 .close-div label {
     cursor: pointer;
     color: hsla(0, 0%, 20%, 1);

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import Eclipse from '../../lib/components/svg/eclipse.svelte';
+  import Eclipse from '../../lib/components/svg/Eclipse.svelte';
 
   let currentSlide = 0;
 

--- a/src/routes/sign-up/+page.server.js
+++ b/src/routes/sign-up/+page.server.js
@@ -1,39 +1,86 @@
 import { fail, redirect } from '@sveltejs/kit';
-import argon2 from 'argon2';
-import getDirectusInstance from '$lib/directus';
-import { createItem } from '@directus/sdk';
+import bcrypt from 'bcryptjs';
+import { createUser, fetchCollection } from '$lib/api';
 
+/**
+ * User registration with sveltekit form actions
+ * Validates input, returns errors for invalid input, and adds the user to the Directus database with a hashed password.
+ */
 export const actions = {
   default: async ({ request, fetch }) => {
     const formData = await request.formData();
     const name = formData.get('name')?.trim();
     const email = formData.get('email')?.trim();
     const password = formData.get('password')
-
-    const directus = getDirectusInstance(fetch);
-
-    /** hier wordt het wachtwoord gehasht met argon2, zodat de wachtwoord beveiligd in de database staat */
+    const passwordConfirm = formData.get('passwordConfirm');
+    const termsAccepted = formData.get('terms');
     let hashedPassword;
-    try {
-      hashedPassword = await argon2.hash(password);
+
+    const errors = {};
+    if (!name) errors.name = "Please fill out this field";
+    if (!email) errors.email = "Please fill out this field";
+    if (!password) {
+      errors.password = "Please fill out this field";
+    } else {
+      const passwordCriteria = [
+        { check: pw => /[a-z]/.test(pw)},
+        { check: pw => /[A-Z]/.test(pw)},
+        { check: pw => /\d/.test(pw)},
+        { check: pw => pw.length >= 8}
+      ];
+      for (const rule of passwordCriteria) {
+        if (!rule.check(password)) {
+          errors.password = "Password must contain: a lowercase letter, an uppercase letter, a number, and minimum 8 characters";
+          break;
+        }
+      }
+    }
+
+    if (!passwordConfirm) {
+      errors.passwordConfirm = "Please fill out this field";
+    } else if (password !== passwordConfirm) {
+      errors.passwordConfirm = "Passwords do not match";
+    }
+
+    if (!termsAccepted) {
+      errors.terms = "You must accept the terms and conditions";
+    }
+
+    if (email && Object.keys(errors).length === 0) {
+      const existingUsers = await fetchCollection(fetch, 'tm_users', {
+        filter: { email: { _eq: email } },
+        limit: 1
+      });
+      if (Array.isArray(existingUsers) && existingUsers.length > 0) {
+        errors.email = "This email address is already registered";
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return fail(400, { errors, values: { name, email, terms: !!termsAccepted } });
+    }
+
+     /** The password is hashed here with bcryptjs, so the password is securely stored in the database */
+     try {
+      hashedPassword = await bcrypt.hash(password, 10);
     } catch (err) {
       return fail(500, { err });
     }
 
-    // De nieuwe gebruiker wordt hiermee toegevoegd aan directus
-    try {
-      await directus.request(
-        createItem('tm_users', {
-          name,
-          email,
-          password: hashedPassword
-        })
-      );
-    } catch (err) {
-      return fail(500, { err });
+     /** The new user is added to Directus */
+     const creationResult = await createUser(fetch, {
+      name,
+      email,
+      password: hashedPassword
+    });
+
+    if (creationResult.status !== 201) {
+      return fail(creationResult.status, { 
+        errors: { general: creationResult.error } 
+      });
     }
 
-    /** als de gebruiker is toegevoegd aan de database, wordt de gebruiker omgeleid naar de choose-buddy pagina om verder te gaan met de registratie */
+    /** If the user is added to the database, they are redirected to the choose-buddy page to continue the registration */
     throw redirect(303, '/choose-buddy');
   }
 };

--- a/src/routes/sign-up/+page.svelte
+++ b/src/routes/sign-up/+page.svelte
@@ -1,9 +1,31 @@
 <script>
 import { Input, Back } from '$lib/index';
 
-</script>
+export let form;
 
-<title>sign-up</title>
+let password = '';
+let showPassword = false;
+let showCriteria = false;
+
+const criteria = [
+  {
+    label: 'A lowercase letter',
+    test: pw => /[a-z]/.test(pw)
+  },
+  {
+    label: 'An uppercase letter',
+    test: pw => /[A-Z]/.test(pw)
+  },
+  {
+    label: 'A number',
+    test: pw => /\d/.test(pw)
+  },
+  {
+    label: 'Minimum 8 characters',
+    test: pw => pw.length >= 8
+  }
+];
+</script>
 <main>
     <section>
         <div class="heading">
@@ -14,18 +36,107 @@ import { Input, Back } from '$lib/index';
         </div>
     
         <form method="POST" action="/sign-up">
-                <Input type="text" name="name" placeholder="Enter your full name"/>
-                <Input type="email" name="email" placeholder="email@example.com"/>
-                <Input type="password" name="password" placeholder="Enter your password"/>
+            <Input 
+                inputClass={form?.errors?.name ? 'is-invalid' : ''}
+                type="text" 
+                name="name" 
+                placeholder="Enter your full name"
+                value={form?.values?.name ?? ''}
+            />
+            {#if form?.errors?.name}
+                <div class="field-error">{form.errors.name}</div>
+            {/if}
 
+            <Input 
+                inputClass={form?.errors?.email ? 'is-invalid' : ''}
+                type="email" 
+                name="email" 
+                placeholder="email@example.com"
+                value={form?.values?.email ?? ''}
+            />
+            {#if form?.errors?.email}
+                <div class="field-error">{form.errors.email}</div>
+            {/if}
+
+
+            <div class="password-field-wrapper">
+                <Input
+                    bind:value={password}
+                    inputClass={form?.errors?.password ? 'is-invalid' : ''}
+                    type={showPassword ? 'text' : 'password'}
+                    name="password"
+                    placeholder="Enter your password"
+                    label="Password" 
+                    on:focus={() => showCriteria = true}
+                    on:blur={() => showCriteria = false}
+                />
+                <button
+                    type="button"
+                    class="toggle-password-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    on:click={() => showPassword = !showPassword}
+                >
+                    {#if showPassword}
+                        <svg width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="#444" stroke-width="2" d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"/><circle cx="12" cy="12" r="3" stroke="#444" stroke-width="2"/></svg>
+                    {:else}
+                        <svg width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="#444" stroke-width="2" d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"/><circle cx="12" cy="12" r="3" stroke="#444" stroke-width="2"/><line x1="4" y1="20" x2="20" y2="4" stroke="#444" stroke-width="2"/></svg>
+                    {/if}
+                </button>
+            </div>
+            {#if form?.errors?.password}
+                <div class="field-error">{form.errors.password}</div>
+            {/if}
+
+            {#if showCriteria || password.length > 0}
+            <div class="password-criteria">
+                <h3>Password must contain the following:</h3>
+                <ul>
+                {#each criteria as item}
+                <li class={item.test(password) ? 'valid' : 'invalid'}>
+                    {#if item.test(password)}
+                        <svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M27 9L13 23L6 16" stroke="#2ecc40" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    {:else}
+                        <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M6 6L14 14M14 6L6 14" stroke="#d32f2f" stroke-width="3" stroke-linecap="round"/>
+                        </svg>
+                    {/if}
+                    {item.label}
+                </li>
+                {/each}
+                </ul>
+            </div>
+            {/if}
+              
+            <Input 
+                inputClass={form?.errors?.passwordConfirm ? 'is-invalid' : ''}
+                type="password" 
+                name="passwordConfirm" 
+                placeholder="Confirm your password"
+                label="Confirm password"
+            />
+            {#if form?.errors?.passwordConfirm}
+                <div class="field-error">{form.errors.passwordConfirm}</div>
+            {/if}
+            
             <article>
+                {#if form?.errors?.terms}
+                    <div class="terms-error">{form.errors.terms}</div>
+                {/if}
+
                 <div class="toggle-row">
-                    <label class="switch">
-                        <input type="checkbox" aria-label="toggle-button">
+                    <label class="switch {form?.errors?.terms ? 'is-invalid' : ''}">
+                        <input 
+                            type="checkbox" 
+                            aria-label="toggle-button"
+                            name="terms"
+                            checked={form?.values?.terms}
+                        >
                         <span class="slider round"></span>
                     </label>
 
-                    <p>Agree to the terms of services and the privacy policy <a href="/click" class="click-here">(click here for more information)</a></p>
+                    <p>Agree to the terms of services and the privacy policy <a href="/click" class="click-here">(click here for more information)</a>*</p>
                 </div>
         
                 <div class="toggle-row">
@@ -49,21 +160,26 @@ import { Input, Back } from '$lib/index';
     padding: 0;
     margin: 0;
 }
+
 section, form, main{
     display: flex;
     flex-direction: column;
 }
+
 main{
     align-items: center;
 }
+
 section {
     padding: 1.25em;
     max-width: 30em ;
     height: 100dvh; 
 }
+
 form {
     flex-grow: 1;
 }
+
 .heading {
     display: flex;
     align-items: center;
@@ -89,9 +205,59 @@ form {
     align-items: center;
 }
 
+.password-field-wrapper {
+  position: relative;
+  flex-direction: column;
+  margin-bottom: 0;
+}
+
+.password-field-wrapper .toggle-password-btn {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  border: none;
+}
+
+.field-error {
+  color: #d32f2f;
+  margin-top: -0.8em;
+  margin-bottom: 0.8em;
+}
+
+.terms-error {
+  color: #d32f2f;
+  margin-bottom: 0.4em; 
+  margin-top: 0.5em;
+}
+
+.password-criteria {
+  background: #f7fafd;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.6em;
+  padding: 1em;
+  flex-direction: column ;
+}
+
+.password-criteria h3 {
+  font-size: 1em;
+  margin-bottom: 0.5em;
+}
+
+.password-criteria li.valid {
+  color: #2ecc40;
+  font-weight: 500;
+}
+
+.password-criteria li.invalid {
+  color: #d32f2f;
+  font-weight: 400;
+}
+
 label{
     font-size: 1.25em;
-}                                                                                
+    margin-bottom: .6em;
+}          
+
 p{
     max-width: 40ch;
 }
@@ -104,9 +270,11 @@ input{
     margin-bottom: 1.25em ;
     font-size: 1em;
 }
+
 label{
     margin-bottom: .6em;
 }
+
 div{
     display: flex;
     flex-direction: row;

--- a/tests/unit/signup.test.js
+++ b/tests/unit/signup.test.js
@@ -1,0 +1,142 @@
+/** @author Marjam Lodien */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { actions } from '../../src/routes/sign-up/+page.server.js';
+
+/** The bcryptjs hash module is mocked so the test does not depend on the library itself, but we can still get a fake hashed password. */
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: vi.fn(async pw => `hashed_${pw}`),
+    compare: vi.fn(async (pw, hash) => hash === `hashed_${pw}`)
+  }
+}));
+
+/** The functions from the api are mocked */
+vi.mock('$lib/api', () => {
+  const fetchCollection = vi.fn();
+  const createUser = vi.fn();
+  return { fetchCollection, createUser, _mocks: { fetchCollection, createUser } };
+});
+
+/** SvelteKit helpers are mocked here. This allows us to simulate redirects and errors in the test */
+vi.mock('@sveltejs/kit', () => ({
+  redirect: (status, location) => {
+    const err = new Error('Redirect');
+    err.status = status;
+    err.location = location;
+    throw err;
+  },
+  fail: (status, data) => ({ status, data }),
+}));
+
+/** This mocks a request object and form object */
+function makeRequest(form) {
+  return {
+    formData: async () => ({
+      get: key => form[key],
+    }),
+  };
+}
+
+describe('Sign-up Unit', () => {
+  let fetchCollection, createUser;
+  /** The beforeEach ensures that before every test the mock functions are retrieved and available for the test */
+  beforeEach(async () => {
+    ({ fetchCollection, createUser } = (await import('$lib/api'))._mocks);
+  });
+
+  it('should succeed when all fields are valid and terms are accepted', async () => {
+    fetchCollection.mockResolvedValue([]);
+    createUser.mockResolvedValue({ status: 201, data: { id: 123 } });
+
+    let redirect;
+    try {
+      await actions.default({
+        request: makeRequest({
+          name: 'user',
+          email: `user@example.com`,
+          password: 'ValidPassword1',
+          passwordConfirm: 'ValidPassword1',
+          terms: 'on',
+        }),
+        fetch: vi.fn(),
+      });
+    } catch (e) {
+      redirect = e;
+    }
+    expect(redirect?.status).toBe(303);
+    expect(redirect?.location).toBe('/choose-buddy');
+  });
+
+  it('should fail if fields are empty', async () => {
+    const res = await actions.default({ request: makeRequest({}), fetch: vi.fn() });
+    expect(res.status).toBe(400);
+    expect(res.data.errors).toMatchObject({
+      name: expect.any(String),
+      email: expect.any(String),
+      password: expect.any(String),
+      passwordConfirm: expect.any(String),
+      terms: expect.any(String),
+    });
+  });
+
+  it('should fail on weak password', async () => {
+    const res = await actions.default({
+      request: makeRequest({
+        name: 'Test',
+        email: 'unique2@example.com',
+        password: 'weak',
+        passwordConfirm: 'weak',
+        terms: 'on',
+      }),
+      fetch: vi.fn(),
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.errors.password).toBeDefined();
+  });
+
+  it('should fail if passwords do not match', async () => {
+    const res = await actions.default({
+      request: makeRequest({
+        name: 'Test',
+        email: 'unique3@example.com',
+        password: 'Password1',
+        passwordConfirm: 'Password2',
+        terms: 'on',
+      }),
+      fetch: vi.fn(),
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.errors.passwordConfirm).toBeDefined();
+  });
+
+  it('should fail if terms not accepted', async () => {
+    const res = await actions.default({
+      request: makeRequest({
+        name: 'Test',
+        email: 'unique4@example.com',
+        password: 'Password1',
+        passwordConfirm: 'Password1',
+        terms: null,
+      }),
+      fetch: vi.fn(),
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.errors.terms).toBeDefined();
+  });
+
+  it('should fail if email already exists', async () => {
+    fetchCollection.mockResolvedValue([{ id: 1, email: 'unique5@example.com' }]);
+    const res = await actions.default({
+      request: makeRequest({
+        name: 'Test',
+        email: 'unique5@example.com',
+        password: 'Password1',
+        passwordConfirm: 'Password1',
+        terms: 'on',
+      }),
+      fetch: vi.fn(),
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.errors.email).toBeDefined();
+  });
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,10 @@ export default defineConfig({
   },
   test: {
     globals: true,       // Maakt globale functies zoals 'vi', 'test', en 'expect' beschikbaar
-	environment: 'jsdom',
-  
+	  environment: 'jsdom',
+    include: [
+      'tests/unit/**/*.{test,spec}.{js,ts}',
+      'tests/integration/**/*.{test,spec}.{js,ts}',
+    ],
   },
 });


### PR DESCRIPTION
## What does this change?

Resolves issue #298 

Bij het aanmaken van een nieuw account hoort het registratieformulier. In dit issue heb ik validatie toegepast aan de velden, zodat wordt gecheckt of de velden niet leeg zijn, de wachtwoorden overeenkomen met elkaar en of de email al geregistreerd staat. De nieuwe gebruiker krijgt live-validatie voor het invullen van het wachtwoord.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
- [x] Unit test

## Images
**BEFORE**
<img width="524" alt="Scherm­afbeelding 2025-05-28 om 15 28 48" src="https://github.com/user-attachments/assets/4adf104d-afd4-4502-9f3e-4b6b838513ce" />

**AFTER**
<img width="495" alt="Scherm­afbeelding 2025-05-28 om 15 29 21" src="https://github.com/user-attachments/assets/833d75ec-b0f5-4b1f-9d68-6a60b3e05cf1" />


<img width="472" alt="Scherm­afbeelding 2025-05-28 om 15 30 58" src="https://github.com/user-attachments/assets/5f9bef28-2f65-4553-aa61-f50da1c3457c" />


<img width="463" alt="Scherm­afbeelding 2025-05-28 om 15 31 22" src="https://github.com/user-attachments/assets/2fb75508-70c3-4874-bce0-2aa7edb640df" />


## How to review

Om dit te testen ga je naar /sign-up en vul je het formulier in om je te registreren. Dit kan op branch 298.