### PR TITLE
fix: fixed the login so it works with hashed passwords #308

### DIFF
--- a/src/routes/log-in/+page.server.js
+++ b/src/routes/log-in/+page.server.js
@@ -1,9 +1,46 @@
-import { fetchAllData } from '$lib/api';
+import { fail, redirect } from '@sveltejs/kit';
+import bcrypt from 'bcryptjs';
+import { fetchCollection } from '$lib/api';
 
-export async function load({ locals }) {
-    const data = await fetchAllData();
+export const actions = {
+  default: async ({ request, fetch }) => {
+    let formData, email, password, users, user, valid = false;
 
-    return {
-        ...data
-    };
-}
+    // Get form data
+    formData = await request.formData();
+    email = formData.get('email-input');
+    password = formData.get('password-input');
+
+    // Check if both fields are filled
+    if (!email || !password) {
+      return fail(400, { error: 'Please fill out both fields.' });
+    }
+
+    // Fetch user from the database by email
+    users = await fetchCollection(fetch, 'tm_users', {
+      filter: { email: { _eq: email } },
+      limit: 1
+    });
+    user = users && users[0];
+
+    // Check if user exists
+    if (!user) {
+      return fail(401, { error: 'Invalid email or password.' });
+    }
+
+    try {
+      // Compare provided password with hashed password
+      valid = await bcrypt.compare(password, user.password);
+    } catch (e) {
+      return fail(500, { error: 'Internal error during login.' });
+    }
+
+    // If password is not valid
+    if (!valid) {
+      return fail(401, { error: 'Invalid email or password.' });
+    }
+
+    // Successful login, redirect to profile selection
+    throw redirect(303, '/profile-selection');
+  }
+};

--- a/src/routes/log-in/+page.svelte
+++ b/src/routes/log-in/+page.svelte
@@ -1,32 +1,15 @@
 <script>
+    import { Input, Close } from '$lib/index';
+
     export let data;
+    export let form;
 
-    import { Input, userState, Close } from '$lib/index';
-    import { goto } from '$app/navigation';
-
-    let users = data.users;
     let email = '';
     let password = '';
-    let errorMessage = '';
+    let popupOpen = false;
 
-    async function handleLogin(event) {
-        event.preventDefault();
-
-        if (!email || !password) {
-            errorMessage = 'Please fill out both fields.';
-            return;
-        }
-
-        const user = users.find((user) => user.email === email && user.password === password);
-
-        if (user) {
-            userState.set({ userId: user.id, profileId: null });
-            
-            await goto('/profile-selection');
-        } else {
-            errorMessage = 'Invalid email or password.';
-        }
-    }
+    $: users = data?.users
+    $: if (form?.error) popupOpen = true;
 </script>
 
 <main>
@@ -42,7 +25,7 @@
     </section>
 
     <div class="popup-container">
-        <input type="checkbox" id="login-popup">
+        <input type="checkbox" id="login-popup" bind:checked={popupOpen}>
         <div class="popup">
             <label for="login-popup" class="transparent-label"></label>
             <div class="popup-inner">
@@ -54,13 +37,13 @@
                     </div>
                 </div>
                 <div class="popup-content">
-                    <form on:submit|preventDefault={handleLogin}>
+                    <form method="post">
                         <ul>
                             <li><Input type="email" name="email-input" placeholder="Email" bind:value={email} /></li>
                             <li><Input type="password" name="password-input" placeholder="Password" bind:value={password} /></li>
                             <li><button type="submit" class="login-popup">Log in</button></li>
-                            {#if errorMessage}
-                            <li class="error-message">{errorMessage}</li>
+                            {#if form?.error}
+                                <li class="error-message">{form.error}</li>
                             {/if}
                             <li><a href="/">I don't remember my password/username</a></li>
                         </ul>
@@ -71,9 +54,7 @@
     </div>
 </main>
 
-
 <style>
-
 :root {
     --color-text: white;;
 
@@ -277,4 +258,4 @@ label {
     margin-top: .6em;
     text-align: center;
 }
-</style>
+</style>  

--- a/tests/Integration/login.test.js
+++ b/tests/Integration/login.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { actions } from '../../src/routes/log-in/+page.server';
+import bcrypt from 'bcryptjs';
+import fc from 'fast-check';
+import { fetchCollection } from '$lib/api';
+
+// Mock the fetchCollection API function for isolation
+vi.mock('$lib/api', () => ({
+  fetchCollection: vi.fn(),
+}));
+
+// Mock SvelteKit's redirect and fail for test control
+vi.mock('@sveltejs/kit', () => ({
+    redirect: (status, location) => {
+      const err = new Error('Redirect');
+      err.status = status;
+      err.location = location;
+      throw err;
+    },
+    fail: (status, data) => ({ status, data }),
+  }));
+
+// Example user for testing login logic
+const testUser = {
+  id: 1,
+  email: 'testuser@example.com',
+  password: bcrypt.hashSync('Test1234', 10),
+};
+
+describe('Login integration tests', () => {
+  // Reset all mocks before each test for isolation
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs in successfully with correct credentials (happy path)', async () => {
+    let redirectError;
+    (fetchCollection).mockResolvedValue([testUser]);
+
+    const request = {
+      formData: async () => new Map([
+        ['email-input', 'testuser@example.com'],
+        ['password-input', 'Test1234'],
+      ]),
+    };
+  
+    try {
+      await actions.default({
+        request,
+        fetch: vi.fn(),
+        locals: {},
+      });
+    } catch (e) {
+      redirectError = e;
+    }
+
+    expect(redirectError).toBeDefined();
+    expect(redirectError.status).toBe(303);
+    expect(redirectError.location).toBe('/profile-selection');
+  });
+
+  it('fails with empty fields', async () => {
+    (fetchCollection).mockResolvedValue([]);
+
+    const request = {
+      formData: async () => new Map([
+        ['email-input', ''],
+        ['password-input', ''],
+      ]),
+    };
+
+    const result = await actions.default({ request, fetch: vi.fn(), locals: {} });
+    expect(result.status).toBe(400);
+    expect(result.data.error).toMatch(/fill out both fields/i);
+  });
+
+  it('fails with unknown email', async () => {
+    (fetchCollection).mockResolvedValue([]);
+
+    const request = {
+      formData: async () => new Map([
+        ['email-input', 'unknown@example.com'],
+        ['password-input', 'Test1234'],
+      ]),
+    };
+
+    const result = await actions.default({ request, fetch: vi.fn(), locals: {} });
+    expect(result.status).toBe(401);
+    expect(result.data.error).toMatch(/invalid email or password/i);
+  });
+
+  it('fails with wrong password', async () => {
+    (fetchCollection).mockResolvedValue([testUser]);
+
+    const request = {
+      formData: async () => new Map([
+        ['email-input', 'testuser@example.com'],
+        ['password-input', 'WrongPassword'],
+      ]),
+    };
+
+    const result = await actions.default({ request, fetch: vi.fn(), locals: {} });
+    expect(result.status).toBe(401);
+    expect(result.data.error).toMatch(/invalid email or password/i);
+  });
+
+  it('never returns plaintext passwords', async () => {
+    expect(testUser.password).not.toBe('Test1234');
+    expect(testUser.password.startsWith('$2')).toBe(true); 
+  });
+
+  it('always returns the same error for unknown email and wrong password', async () => {
+    (fetchCollection).mockResolvedValue([]);
+
+    let result = await actions.default({
+      request: {
+        formData: async () => new Map([
+          ['email-input', 'unknown@example.com'],
+          ['password-input', 'Test1234'],
+        ]),
+      },
+      fetch: vi.fn(),
+      locals: {},
+    });
+    
+    const errorMsg1 = result.data.error;
+
+    (fetchCollection).mockResolvedValue([testUser]);
+    result = await actions.default({
+      request: {
+        formData: async () => new Map([
+          ['email-input', 'testuser@example.com'],
+          ['password-input', 'WrongPassword'],
+        ]),
+      },
+      fetch: vi.fn(),
+      locals: {},
+    });
+    const errorMsg2 = result.data.error;
+
+    expect(errorMsg1).toBe(errorMsg2);
+  });
+
+  it('login with minimum password length', async () => {
+    const minPw = 'Abcdef12';
+    let redirectError;
+    const userWithMinPw = { ...testUser, password: bcrypt.hashSync(minPw, 10) };
+    (fetchCollection).mockResolvedValue([userWithMinPw]);
+
+    const request = {
+      formData: async () => new Map([
+        ['email-input', 'testuser@example.com'],
+        ['password-input', minPw],
+      ]),
+    };
+
+    try {
+      await actions.default({
+        request,
+        fetch: vi.fn(),
+        locals: {},
+      });
+    } catch (e) {
+      redirectError = e;
+    }
+    expect(redirectError).toBeDefined();
+    expect(redirectError.status).toBe(303);
+    expect(redirectError.location).toBe('/profile-selection');
+  });  
+
+  it('property: system responds appropriately to random input', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        async (email, password) => {
+          const request = {
+            formData: async () => new Map([
+              ['email-input', email],
+              ['password-input', password],
+            ]),
+          };
+  
+          try {
+            const result = await actions.default({ request, fetch: vi.fn(), locals: {} });
+            expect([400, 401]).toContain(result.status);
+            expect(result.data?.error).toBeDefined();
+          } catch (e) {
+            expect(e.status).toBe(303);
+            expect(e.location).toBe('/profile-selection');
+          }
+        }
+      ),
+      { numRuns: 10 }
+    );
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
 	  environment: 'jsdom',
     include: [
       'tests/unit/**/*.{test,spec}.{js,ts}',
-      'tests/integration/**/*.{test,spec}.{js,ts}',
+      'tests/Integration/**/*.{test,spec}.{js,ts}',
     ],
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
 	  environment: 'jsdom',
     include: [
       'tests/unit/**/*.{test,spec}.{js,ts}',
-      'tests/Integration/**/*.{test,spec}.{js,ts}',
+      'tests/integration/**/*.{test,spec}.{js,ts}',
     ],
   },
 });


### PR DESCRIPTION
## What does this change?

Resolves issue #308

With the new registration functionality, the passwords are hashed in directus. I changed the login functionality so you can also log in with the hashed password. First the log in only worked with plaintext passwords, but now this is not allowed anymore due to safety. The system only allows hashed passwords.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
- [x] Integration test
- [x] Property based test
- [x] Unit test

## How to review
Go to /sign-up to make a new account using the registration form. After that you can go to /log-in to log in with your new account using your email and password.
