### PR TITLE
refactor: playlist detail page

### DIFF
--- a/src/lib/components/core/DeleteDialog.svelte
+++ b/src/lib/components/core/DeleteDialog.svelte
@@ -1,7 +1,22 @@
 <script>
+  import { deleteFromCollection } from '$lib/api.js';
   import { DeleteSVG } from '$lib/index';
-  export let playlistId;
-  export let onDelete;
+
+  export let playlist;
+  export let setError;
+
+  async function deletePlaylist(event) {
+    event.preventDefault();
+    if (!playlist?.id) return;
+
+    try {
+      await deleteFromCollection(fetch, 'tm_playlist', playlist.id);
+      window.location.href = '/lessons';
+    } catch (err) {
+      console.error('Error deleting playlist:', err);
+      setError(err.message || 'Er is iets fout gegaan bij verwijderen.');
+    }
+  }
 </script>
 
 <dialog id="delete">
@@ -13,8 +28,14 @@
 
     <div class="popup-btns">
       <a href="#cancelled" class="black-text cancel-btn">Cancel</a>
-      <form method="POST" action={`/lessons/delete/${playlistId}`} on:submit|preventDefault={onDelete}>
-        <button type="submit" class="delete-btn">Delete <DeleteSVG /></button>
+      <form
+        method="POST"
+        action={`/lessons/delete/${playlist.id}`}
+        on:submit|preventDefault={deletePlaylist}
+      >
+        <button type="submit" class="delete-btn">
+          Delete <DeleteSVG />
+        </button>
       </form>
     </div>
   </div>
@@ -56,7 +77,7 @@ dialog{
   flex-direction: column;
   text-align: left;
   padding: 1em;
-  padding-left: 1.5em
+  padding-left: 1.5em;
 }
 
 .delete-content > h2{
@@ -101,6 +122,7 @@ dialog:target .delete-content {
   gap: .3em;
   font-size: 1em;
   border: none;
+  cursor: pointer;
 }
 
 .delete-btn:hover{
@@ -111,68 +133,5 @@ dialog:target .delete-content {
   display: flex;
   align-items: center;
 }
-
-/* test */
-
-dialog {
-  background-color: rgba(0, 0, 0, 0.8);
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.3s;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 100%;
-  height: 110vh;
-  border: none;
-  z-index: 9999;
-}
-.delete-content {
-  background-color: #fff;
-  max-width: 25em;
-  width: 90%;
-  height: 14em;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  border-radius: var(--border-radius);
-  padding: 1em 1.5em;
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-}
-.popup-btns {
-  margin-top: auto;
-  margin-left: auto;
-  display: flex;
-}
-.black-text {
-  color: black;
-}
-dialog:target {
-  opacity: 1;
-  visibility: visible;
-}
-.cancel-btn, .delete-btn {
-  padding: .5em .7em;
-  border-radius: var(--border-radius);
-  font-weight: var(--font-weight-normal);
-}
-.cancel-btn {
-  border: 1px solid black;
-}
-.delete-btn {
-  margin-left: .5em;
-  background-color: #D51D1D;
-  display: flex;
-  align-items: center;
-  gap: .3em;
-  border: none;
-  font-size: 1em;
-  cursor: pointer;
-}
-
 
 </style>

--- a/src/lib/components/core/DeleteDialog.svelte
+++ b/src/lib/components/core/DeleteDialog.svelte
@@ -1,0 +1,178 @@
+<script>
+  import { DeleteSVG } from '$lib/index';
+  export let playlistId;
+  export let onDelete;
+</script>
+
+<dialog id="delete">
+  <div class="delete-content">
+    <h2 class="black-text">Delete this playlist?</h2>
+    <p class="black-text">
+      It will be permanently removed from your profile, and you won't be able to recover it.
+    </p>
+
+    <div class="popup-btns">
+      <a href="#cancelled" class="black-text cancel-btn">Cancel</a>
+      <form method="POST" action={`/lessons/delete/${playlistId}`} on:submit|preventDefault={onDelete}>
+        <button type="submit" class="delete-btn">Delete <DeleteSVG /></button>
+      </form>
+    </div>
+  </div>
+</dialog>
+
+<style>
+
+dialog{
+  background-color: rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 110vh;
+  border: none;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  z-index: 9999;
+}
+
+.delete-content{
+  transform: translate(-50%, -50%);
+  text-align: center;
+  background-color: #fff;
+  max-width: 25em;
+  width: 90%;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  height: 14em;
+  overflow: hidden;
+  border: none;
+  border-radius: var(--border-radius);
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  padding: 1em;
+  padding-left: 1.5em
+}
+
+.delete-content > h2{
+  margin-bottom: 1em;
+}
+
+.popup-btns{
+  margin-top: auto;
+  margin-left: auto;
+  display: flex;
+}
+
+.black-text{
+  color: black;
+}
+
+dialog:target {
+  opacity: 1;
+  visibility: visible;
+}
+
+dialog:target .delete-content {
+  opacity: 1;
+}
+
+.cancel-btn, .delete-btn{
+  padding: .5em .7em .5em .7em;
+  border-radius: var(--border-radius);
+  font-weight: var(--font-weight-normal);
+}
+
+.cancel-btn{
+  border: 1px solid black;
+}
+
+.delete-btn{
+  margin-left: .5em;
+  background-color: #D51D1D;
+  color: var(--color-white);
+  display: flex;
+  align-items: center;
+  gap: .3em;
+  font-size: 1em;
+  border: none;
+}
+
+.delete-btn:hover{
+  cursor: pointer;
+}
+
+.popup-btns a {
+  display: flex;
+  align-items: center;
+}
+
+/* test */
+
+dialog {
+  background-color: rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 110vh;
+  border: none;
+  z-index: 9999;
+}
+.delete-content {
+  background-color: #fff;
+  max-width: 25em;
+  width: 90%;
+  height: 14em;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: var(--border-radius);
+  padding: 1em 1.5em;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+.popup-btns {
+  margin-top: auto;
+  margin-left: auto;
+  display: flex;
+}
+.black-text {
+  color: black;
+}
+dialog:target {
+  opacity: 1;
+  visibility: visible;
+}
+.cancel-btn, .delete-btn {
+  padding: .5em .7em;
+  border-radius: var(--border-radius);
+  font-weight: var(--font-weight-normal);
+}
+.cancel-btn {
+  border: 1px solid black;
+}
+.delete-btn {
+  margin-left: .5em;
+  background-color: #D51D1D;
+  display: flex;
+  align-items: center;
+  gap: .3em;
+  border: none;
+  font-size: 1em;
+  cursor: pointer;
+}
+
+
+</style>

--- a/src/lib/components/core/PlaylistHeader.svelte
+++ b/src/lib/components/core/PlaylistHeader.svelte
@@ -1,0 +1,108 @@
+<script>
+  import { Back, Dropdown } from '$lib/index';
+  export let playlist;
+</script>
+
+<header>
+  <nav id="cancelled">
+    <a href="/lessons" aria-label="go back" class="go-back-btn"><Back /></a>
+    <Dropdown />
+  </nav>
+
+  <picture class="playlist-image-container">
+    <source srcset="{playlist.image}?width=448&format=avif" type="image/avif" />
+    <source srcset="{playlist.image}?width=448&format=webp" type="image/webp" />
+    <source srcset="{playlist.image}?width=448" type="image/jpeg" />
+    <img
+      src="{playlist.image}?width=64"
+      alt="playlist"
+      height="380"
+      width="448"
+      class="playlist-image"
+      style="view-transition-name:playlist-image-{playlist.id};"
+    />
+  </picture>
+</header>
+
+<style>
+
+.go-back-btn{
+  z-index: 10;
+}
+
+nav {
+  max-width: 31.25em;
+  width: 100%;
+  flex-wrap: wrap;
+  padding: var(--space-md);
+  position: absolute;
+  margin-top: 2em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.playlist-image-container {
+  z-index: 0;
+  height: auto; 
+  aspect-ratio: 1 / 1; 
+  overflow: hidden; 
+  padding: 1em 1em 0 1em;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.playlist-image {
+  height: calc(100% - 5em); 
+  width: calc(100% - 5em); 
+  aspect-ratio: 1 / 1;
+  object-fit: cover; 
+  display: block; 
+  border-radius: var(--border-radius);
+}
+
+header{
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+
+
+/*  test */
+
+nav {
+  position: absolute;
+  width: 100%;
+  margin-top: 2em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-md);
+}
+.playlist-image-container {
+  z-index: 0;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  padding: 1em 1em 0 1em;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+.playlist-image {
+  height: calc(100% - 5em);
+  width: calc(100% - 5em);
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  display: block;
+  border-radius: var(--border-radius);
+}
+</style>

--- a/src/lib/components/core/PlaylistHeader.svelte
+++ b/src/lib/components/core/PlaylistHeader.svelte
@@ -48,7 +48,6 @@ nav {
   aspect-ratio: 1 / 1; 
   overflow: hidden; 
   padding: 1em 1em 0 1em;
-
   position: relative;
   display: flex;
   flex-direction: column;
@@ -75,34 +74,4 @@ header{
 }
 
 
-/*  test */
-
-nav {
-  position: absolute;
-  width: 100%;
-  margin-top: 2em;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-md);
-}
-.playlist-image-container {
-  z-index: 0;
-  aspect-ratio: 1 / 1;
-  overflow: hidden;
-  padding: 1em 1em 0 1em;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-}
-.playlist-image {
-  height: calc(100% - 5em);
-  width: calc(100% - 5em);
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
-  display: block;
-  border-radius: var(--border-radius);
-}
 </style>

--- a/src/lib/components/core/PlaylistMeta.svelte
+++ b/src/lib/components/core/PlaylistMeta.svelte
@@ -1,7 +1,31 @@
 <script>
+  import { fetchApi } from '$lib/index';
+
   export let playlist;
-  export let isLiked;
-  export let toggleLike;
+  export let isLiked = false;
+  let existingLikeId = playlist?.likeId || null;
+  let error = null;
+  let profileId = 122; 
+
+  async function toggleLike(event) {
+    event.preventDefault();
+    const endpoint = isLiked ? `/tm_likes/${existingLikeId}` : '/tm_likes';
+    const method = isLiked ? 'DELETE' : 'POST';
+
+    try {
+      const response = await fetchApi(endpoint, method, {
+        playlist: playlist.id,
+        profile: profileId
+      });
+
+      isLiked = !isLiked;
+      existingLikeId = response?.id || null;
+      playlist = { ...playlist, isLiked, likeId: existingLikeId };
+    } catch (err) {
+      console.error('Error toggling like:', err);
+      error = err.message || 'Er is iets fout gegaan';
+    }
+  }
 </script>
 
 <section class="meta-section">
@@ -31,10 +55,13 @@
     </button>
     <a href="/play"><img src="/icons/play.svg" alt="play" height="60" /></a>
   </div>
+
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
 </section>
 
 <style>
-
 .meta-section {
   padding: var(--space-md);
   max-width: 31.25em;
@@ -91,5 +118,4 @@
     transform: scale(1.4);
   }
 }
-
 </style>

--- a/src/lib/components/core/PlaylistMeta.svelte
+++ b/src/lib/components/core/PlaylistMeta.svelte
@@ -1,0 +1,95 @@
+<script>
+  export let playlist;
+  export let isLiked;
+  export let toggleLike;
+</script>
+
+<section class="meta-section">
+  <h1 style="view-transition-name:playlist-title-{playlist.id};">
+    {playlist.title}
+  </h1>
+  <p>{playlist.description}</p>
+
+  <div class="meta-info">
+    <img src="/icons/profile-icon.svg" alt="profile" height="30" />
+    <p>Made by <strong>User {playlist.creator}</strong></p>
+    <img src="/icons/clock.svg" alt="time" height="20" />
+    <p>2u 11m</p>
+  </div>
+
+  <div class="meta-play" style="view-transition-name:playlist-play-{playlist.id};">
+    <a href="/download"><img src="/icons/download.svg" alt="download" height="27" /></a>
+    <button
+      on:click={toggleLike}
+      class="heart-svg"
+      aria-label="{isLiked ? 'Unlike' : 'Like'}"
+      style="view-transition-name:playlist-like-{playlist.id};"
+    >
+      <svg width="24" height="24" viewBox="0 0 24 24" class:liked={isLiked}>
+        <path d="M11.6536 7.15238C11.8471 7.33832 12.1529 7.33832 12.3464 7.15238C13.1829 6.34871 14.326 5.75 15.6 5.75C18.1489 5.75 20.25 7.64769 20.25 10.0298C20.25 11.7261 19.4577 13.1809 18.348 14.428C17.2397 15.6736 15.7972 16.7316 14.4588 17.6376L12.1401 19.207C12.0555 19.2643 11.9445 19.2643 11.8599 19.207L9.54125 17.6376C8.20278 16.7316 6.76035 15.6736 5.65201 14.428C4.54225 13.1809 3.75 11.7261 3.75 10.0298C3.75 7.64769 5.85106 5.75 8.4 5.75C9.67403 5.75 10.8171 6.34871 11.6536 7.15238Z" stroke="#C4C4C4" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <a href="/play"><img src="/icons/play.svg" alt="play" height="60" /></a>
+  </div>
+</section>
+
+<style>
+
+.meta-section {
+  padding: var(--space-md);
+  max-width: 31.25em;
+  width: 100%;
+  color: var(--color-white);
+}
+
+.meta-info,
+.meta-play {
+  display: flex;
+  align-items: center;
+  max-width: 31.25em;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.meta-info {
+  margin-top: 1em;
+}
+
+.meta-info > p:nth-of-type(1) {
+  margin-right: auto;
+}
+
+.meta-info > img {
+  padding-right: 0.3em;
+}
+
+.heart-svg {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0 auto 0 0.5em;
+}
+
+.heart-svg svg {
+  width: 2.5em;
+  height: 3em;
+  fill: transparent;
+}
+
+.heart-svg svg.liked {
+  fill: #f33232;
+  stroke: #f33232;
+  animation: scale 0.5s ease-in;
+}
+
+@keyframes scale {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.4);
+  }
+}
+
+</style>

--- a/src/lib/components/core/PlaylistStories.svelte
+++ b/src/lib/components/core/PlaylistStories.svelte
@@ -1,0 +1,50 @@
+<script>
+  import { Story } from '$lib/index';
+  export let stories = [];
+</script>
+
+{#if stories.length > 0}
+  <section class="stories-section">
+    <ul>
+      {#each stories as story}
+        <li><Story {story} /></li>
+      {/each}
+    </ul>
+  </section>
+{:else}
+  <section class="no-playlist">
+    <p>Playlist not found.</p>
+    <a href="/lessons" class="view-all">View all playlists</a>
+  </section>
+{/if}
+
+<style>
+
+.stories-section {
+  height: 25em;
+  overflow-y: scroll;
+  width: 100%;
+  scrollbar-width: none;
+}
+
+.stories-section > ul {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625em;
+  align-items: center;
+}
+
+.no-playlist {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 10em;
+  width: 100%;
+  color: var(--color-white);
+}
+
+.view-all {
+  text-decoration: underline;
+}
+</style>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,11 @@ export { default as Menu } from '$lib/components/core/Menu.svelte'
 export { default as Carousel } from '$lib/components/core/Carousel.svelte'
 export { default as Dropdown } from '$lib/components/core/Dropdown.svelte'
 
+export { default as DeleteDialog } from '$lib/components/core/DeleteDialog.svelte'
+export { default as PlaylistHeader } from '$lib/components/core/PlaylistHeader.svelte'
+export { default as PlaylistMeta } from '$lib/components/core/PlaylistMeta.svelte'
+export { default as PlaylistStories } from '$lib/components/core/PlaylistStories.svelte'
+
 export { default as Button } from '$lib/components/forms/ContinueBtn.svelte'
 export { default as Filter } from '$lib/components/forms/Filter.svelte'
 export { default as Input } from '$lib/components/forms/Input.svelte'

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -5,17 +5,14 @@
   let playlist = data?.playlist;
   let isLoading = !playlist;
   let error = null;
-
   $: if (playlist) isLoading = false;
-
 
 </script>
 
 <main>
   <article>
     <PlaylistHeader {playlist} />
-    <!-- <PlaylistMeta {playlist} {isLiked} {toggleLike} /> -->
-     <PlaylistMeta {playlist} isLiked={playlist.isLiked} />
+    <PlaylistMeta {playlist} isLiked={playlist.isLiked} />
 
     {#if isLoading}
       <div class="loading">Loading playlist...</div>
@@ -27,7 +24,6 @@
   </article>
 
    <DeleteDialog {playlist} setError={(msg) => error = msg} />
-
 </main>
 
 <style>

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script>
   import { fetchApi, DeleteDialog, PlaylistStories, PlaylistMeta, PlaylistHeader  } from '$lib/index';
-  import { deleteFromCollection } from '$lib/api.js';
 
   export let data;
   let playlist = data?.playlist;
@@ -33,17 +32,6 @@
     }
   }
 
-  async function deletePlaylist(event) {
-    event.preventDefault();
-    if (!playlist?.id) return;
-    try {
-      await deleteFromCollection(fetch, 'tm_playlist', playlist.id);
-      window.location.href = '/lessons';
-    } catch (err) {
-      console.error('Error deleting playlist:', err);
-      error = err.message || 'Er is iets fout gegaan bij verwijderen.';
-    }
-  }
 </script>
 
 <main>
@@ -60,7 +48,8 @@
     {/if}
   </article>
 
-  <DeleteDialog playlistId={playlist.id} onDelete={deletePlaylist} />
+   <DeleteDialog {playlist} setError={(msg) => error = msg} />
+
 </main>
 
 <style>

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -1,56 +1,41 @@
 <script>
-  import { Story, fetchApi, Back, Dropdown, DeleteSVG  } from '$lib/index';
+  import { fetchApi, DeleteDialog, PlaylistStories, PlaylistMeta, PlaylistHeader  } from '$lib/index';
   import { deleteFromCollection } from '$lib/api.js';
 
   export let data;
- 
   let playlist = data?.playlist;
-
   let isLoading = !playlist;
   let error = null;
 
-  $: {
-    if (playlist) {
-      isLoading = false;
-    }
-  }
+  $: if (playlist) isLoading = false;
 
   let isLiked = playlist?.isLiked || false;
   let existingLikeId = playlist?.likeId || null;
   let profileId = 122;
- 
-// Like playlist function
+
   async function toggleLike(event) {
     event.preventDefault();
- 
     const endpoint = isLiked ? `/tm_likes/${existingLikeId}` : '/tm_likes';
     const method = isLiked ? 'DELETE' : 'POST';
- 
+
     try {
       const response = await fetchApi(endpoint, method, {
         playlist: playlist.id,
         profile: profileId
       });
- 
+
       isLiked = !isLiked;
       existingLikeId = response?.id || null;
       playlist = { ...playlist, isLiked, likeId: existingLikeId };
- 
     } catch (err) {
       console.error('Error toggling like:', err);
       error = err.message || 'Er is iets fout gegaan';
     }
   }
 
-// Delete playlist function
   async function deletePlaylist(event) {
     event.preventDefault();
-
-    if (!playlist?.id) {
-      console.error('Geen playlist ID gevonden.');
-      return;
-    }
-
+    if (!playlist?.id) return;
     try {
       await deleteFromCollection(fetch, 'tm_playlist', playlist.id);
       window.location.href = '/lessons';
@@ -59,350 +44,41 @@
       error = err.message || 'Er is iets fout gegaan bij verwijderen.';
     }
   }
-
 </script>
 
 <main>
   <article>
-      <header>
-      <nav id="cancelled">
-        <a href="/lessons" aria-label="go back" class="go-back-btn"><Back/></a>
-        <Dropdown/>
-      </nav>
+    <PlaylistHeader {playlist} />
+    <PlaylistMeta {playlist} {isLiked} {toggleLike} />
 
-      <picture class="playlist-image-container">
-        <source srcset="{playlist.image}?width=448&format=avif" type="image/avif">
-        <source srcset="{playlist.image}?width=448&format=webp" type="image/webp">
-        <source srcset="{playlist.image}?width=448" type="image/jpeg">
-        <img 
-          src="{playlist.image}?width=64" 
-          alt="playlist"
-          height="380" 
-          width="448" 
-          class="playlist-image"
-          style="view-transition-name:playlist-image-{playlist.id};"
-        />
-      </picture>
-    </header>
-
-   <section class="meta-section">
-    <h1 style="view-transition-name:playlist-title-{playlist.id};">
-      {playlist.title}
-    </h1>
-    <p>{playlist.description}</p>
-
-    <div class="meta-info">
-      <img src="/icons/profile-icon.svg" alt="profile" height="30">
-      <p>Made by <strong>User { playlist.creator }</strong></p>
-      <img src="/icons/clock.svg" alt="time" height="20">
-      <p>2u 11m</p>
-      </div>
-
-     <div class="meta-play"  style="view-transition-name:playlist-play-{playlist.id};">
-        <a href="/download"><img src="/icons/download.svg" alt="download" height="27"></a>
-        <button on:click={toggleLike} 
-          class="heart-svg" 
-          aria-label="{isLiked ? 'Unlike' : 'Like'}" 
-          style="view-transition-name:playlist-like-{playlist.id};">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class:liked={isLiked}>
-              <path d="M11.6536 7.15238C11.8471 7.33832 12.1529 7.33832 12.3464 7.15238C13.1829 6.34871 14.326 5.75 15.6 5.75C18.1489 5.75 20.25 7.64769 20.25 10.0298C20.25 11.7261 19.4577 13.1809 18.348 14.428C17.2397 15.6736 15.7972 16.7316 14.4588 17.6376L12.1401 19.207C12.0555 19.2643 11.9445 19.2643 11.8599 19.207L9.54125 17.6376C8.20278 16.7316 6.76035 15.6736 5.65201 14.428C4.54225 13.1809 3.75 11.7261 3.75 10.0298C3.75 7.64769 5.85106 5.75 8.4 5.75C9.67403 5.75 10.8171 6.34871 11.6536 7.15238Z" stroke="#C4C4C4" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-        </button>
-        <a href="/play"><img src="/icons/play.svg" alt="play" height="60"></a>
-    </div>
-  </section>
-
-  {#if isLoading}
-    <div class="loading">Loading playlist...</div>
-  {:else if error}
-    <p class="error">Error loading playlist: {error}</p>
-  {:else if playlist && playlist.stories.length > 0}
-    <section class="stories-section">
-      <ul>
-        {#each playlist.stories as story}
-        <li>
-          <Story {story} />
-        </li>
-        {/each}
-      </ul>
-    </section>
-  {:else}
-    <section class="no-playlist">
-      <p>Playlist not found.</p>
-      <a href="/lessons" class="view-all">View all playlists</a>
-    </section>
-  {/if}
+    {#if isLoading}
+      <div class="loading">Loading playlist...</div>
+    {:else if error}
+      <p class="error">Error loading playlist: {error}</p>
+    {:else}
+      <PlaylistStories stories={playlist.stories} />
+    {/if}
   </article>
 
-
-  <dialog id="delete">
-    <div class="delete-content">
-      <h2 class="black-text">Delete this playlist?</h2>
-      <p class="black-text">It will be permanently removed from your profile, and you won't be able to recover it.</p>
-
-      <div class="popup-btns">
-        <a href='#cancelled' class="black-text cancel-btn">Cancel</a>
-        <form method="POST" action={`/lessons/delete/${playlist.id}`} on:submit|preventDefault={deletePlaylist}>
-          <button type="submit" class="delete-btn">Delete <DeleteSVG/></button>
-        </form>
-      </div>
-    </div>
-  </dialog>
-
+  <DeleteDialog playlistId={playlist.id} onDelete={deletePlaylist} />
 </main>
 
 <style>
-  
-* {
-  color: var(--color-text-light);
-}
-
-main{
-  display: flex;
-  background-image: var(--bg-image-playlist);
-  min-height: 100vh;
-}
-
-.view-all{
-  text-decoration: underline;
-}
-
-.go-back-btn{
-  z-index: 10;
-}
-
-nav, .meta-section {
-  padding: var(--space-md);
-}
-
-nav, .meta-section, .meta-info, .meta-play {
-  max-width: 31.25em;
-  width: 100%;
-  flex-wrap: wrap;
-}
-
-.playlist-image-container {
-  z-index: 0;
-  height: auto; 
-  aspect-ratio: 1 / 1; 
-  overflow: hidden; 
-  padding: 1em 1em 0 1em;
-
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-}
-
-.playlist-image {
-  height: calc(100% - 5em); 
-  width: calc(100% - 5em); 
-  aspect-ratio: 1 / 1;
-  object-fit: cover; 
-  display: block; 
-  border-radius: var(--border-radius);
-}
 
 article {
   margin: 0 auto;
   height: max-content;
-  width: 31.25em;;
+  width: 31.25em;
   display: flex;
   flex-direction: column;
   align-items: start;
   justify-content: center;
 }
 
-header{
-  width: 100%;
+main {
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-}
-
-nav{
-  position: absolute;
-  width: 100%;
-  margin-top: 2em;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-a {
-  z-index: 0;
-}
-
-/* styling for meta info */
-.meta-info, .meta-play {
-  display: flex;
-  align-items: center;
-}
-
-.meta-info {
-  margin-top: 1em;
-}
-
-.meta-info > p:nth-of-type(1) {
-  margin-right: auto;
-}
-
-.meta-info > img {
-  padding-right: .3em;
-}
-
-.heart-svg {
-  margin: 0 auto 0 .5em;
-}
-
-/* styling for stories section */
-.stories-section {
-  height: 25em; 
-  overflow-y: scroll;
-  width: 100%; 
-  scrollbar-width: none;
-}
-
-.stories-section > ul {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  gap: 0.625em;
-}
-
-.no-playlist{
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 10em; 
-}
-
-.heart-svg {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  margin: 0 auto 0 .5em;
-}
-
-.heart-svg svg {
-  width: 24px;
-  height: 24px;
-}
-
-.heart-svg svg.liked {
-  fill: #F33232;
-  stroke: #F33232;
-}
-
-@keyframes scale {
-  0%, 100% {
-  transform: scale(1);
-  }
-  50% {
-  transform: scale(1.4);
-  }
-}
-.heart-svg svg.liked {
-  animation: scale .5s ease-in;
-}
-
-/* Styling for delete popup */
-
-dialog{
-  background-color: rgba(0, 0, 0, 0.8);
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.3s;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  display: flex;
-  transform: translate(-50%, -50%);
-  width: 100%;
-  height: 110vh;
-  border: none;
-  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-  z-index: 9999;
-}
-
-.delete-content{
-  transform: translate(-50%, -50%);
-  text-align: center;
-  background-color: #fff;
-  max-width: 25em;
-  width: 90%;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  height: 14em;
-  overflow: hidden;
-  border: none;
-  border-radius: var(--border-radius);
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-  padding: 1em;
-  padding-left: 1.5em
-}
-
-.delete-content > h2{
-  margin-bottom: 1em;
-}
-
-.popup-btns{
-  margin-top: auto;
-  margin-left: auto;
-  display: flex;
-}
-
-.black-text{
-  color: black;
-}
-
-dialog:target {
-  opacity: 1;
-  visibility: visible;
-}
-
-dialog:target .delete-content {
-  opacity: 1;
-}
-
-.cancel-btn, .delete-btn{
-  padding: .5em .7em .5em .7em;
-  border-radius: var(--border-radius);
-  font-weight: var(--font-weight-normal);
-}
-
-.cancel-btn{
-  border: 1px solid black;
-}
-
-.delete-btn{
-  margin-left: .5em;
-  background-color: #D51D1D;
-  display: flex;
-  align-items: center;
-  gap: .3em;
-  font-size: 1em;
-  border: none;
-}
-
-.delete-btn:hover{
-  cursor: pointer;
-}
-
-.popup-btns a {
-  display: flex;
-  align-items: center;
+  background-image: var(--bg-image-playlist);
+  min-height: 100vh;
 }
 
 </style>
-

--- a/src/routes/playlist/[id]/+page.svelte
+++ b/src/routes/playlist/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fetchApi, DeleteDialog, PlaylistStories, PlaylistMeta, PlaylistHeader  } from '$lib/index';
+  import { DeleteDialog, PlaylistStories, PlaylistMeta, PlaylistHeader  } from '$lib/index';
 
   export let data;
   let playlist = data?.playlist;
@@ -8,36 +8,14 @@
 
   $: if (playlist) isLoading = false;
 
-  let isLiked = playlist?.isLiked || false;
-  let existingLikeId = playlist?.likeId || null;
-  let profileId = 122;
-
-  async function toggleLike(event) {
-    event.preventDefault();
-    const endpoint = isLiked ? `/tm_likes/${existingLikeId}` : '/tm_likes';
-    const method = isLiked ? 'DELETE' : 'POST';
-
-    try {
-      const response = await fetchApi(endpoint, method, {
-        playlist: playlist.id,
-        profile: profileId
-      });
-
-      isLiked = !isLiked;
-      existingLikeId = response?.id || null;
-      playlist = { ...playlist, isLiked, likeId: existingLikeId };
-    } catch (err) {
-      console.error('Error toggling like:', err);
-      error = err.message || 'Er is iets fout gegaan';
-    }
-  }
 
 </script>
 
 <main>
   <article>
     <PlaylistHeader {playlist} />
-    <PlaylistMeta {playlist} {isLiked} {toggleLike} />
+    <!-- <PlaylistMeta {playlist} {isLiked} {toggleLike} /> -->
+     <PlaylistMeta {playlist} isLiked={playlist.isLiked} />
 
     {#if isLoading}
       <div class="loading">Loading playlist...</div>


### PR DESCRIPTION
## What does this change?

This PR refactors the playlist detail page into using components instead of the whole HTML in one file. The page now consists of components and a little bit of HTML.

Resolves #348


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

Tested by comparing the dev online site and the deployed site

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="580" height="368" alt="image" src="https://github.com/user-attachments/assets/effed472-34ad-4705-a5ff-4d8f4ef76770" />



## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
- Verify if page functions how its supposed to
- If the code is readable and the structure is good
- If there are styling issues

live link: https://deploy-preview-352--tumimundo-dev.netlify.app/playlist/3293