### PR TITLE
Move functions to components & Dynamic header

### DIFF
--- a/src/lib/components/core/Heading.svelte
+++ b/src/lib/components/core/Heading.svelte
@@ -67,6 +67,7 @@
   flex-direction: row;
   justify-content: space-evenly;
   width: 100%;
+  max-width: 31.25em;
 }
 
 .navigation > a {
@@ -113,6 +114,7 @@ p {
   text-align: center;
   margin-bottom: 2.5em;
   width: 100%;
+  max-width: 31.25em;
 } 
 </style>
 

--- a/src/lib/components/core/Heading.svelte
+++ b/src/lib/components/core/Heading.svelte
@@ -36,7 +36,7 @@
   <!-- Cancelled nav -->
   <nav id="cancelled" class="playlist-nav">
     <a href={backHref || '/lessons'} aria-label="go back" class="go-back-btn">
-      <Back color={backColor} />
+      <Back />
     </a>
     {#if showDropdown}
       <Dropdown />

--- a/src/lib/components/core/Heading.svelte
+++ b/src/lib/components/core/Heading.svelte
@@ -1,29 +1,118 @@
 <script>
-  import { Back } from '$lib/index';
+  import { Back, Dropdown } from '$lib/index';
+  export let variant = 'stories';
+  export let title = '';
+  export let backHref = '';
+  export let backColor = 'white';
+  export let showDropdown = true; 
 </script>
 
-<header>
-  <div class="heading">
-    <a href="/lessons" aria-label="Go back to lessons">
-      <Back color="white"/>
+{#if variant === 'stories'}
+  <!-- All stories nav-->
+  <header class="stories-header">
+    <div class="heading">
+      <a href={backHref || '/lessons'} aria-label="Go back to lessons">
+        <Back color={backColor} />
+      </a>
+      <h1>{title || 'All Stories'}</h1>
+    </div>
+  </header>
+
+{:else if variant === 'languages'}
+  <!-- Languages nav -->
+  <nav class="navigation">
+    <a href={backHref || '/onboarding'} aria-label="Go back to onboarding">
+      <Back color={backColor} />
     </a>
-    <h1>All Stories</h1>
-  </div>
-</header>
+    <h1>{title || 'We are going to learn!'}</h1>
+  </nav>
+
+  <p>
+    Now it is time to pick the language(s) your child will learn.
+    You can pick a <strong>maximum of 3</strong> languages.
+  </p>
+
+{:else}
+  <!-- Cancelled nav -->
+  <nav id="cancelled" class="playlist-nav">
+    <a href={backHref || '/lessons'} aria-label="go back" class="go-back-btn">
+      <Back color={backColor} />
+    </a>
+    {#if showDropdown}
+      <Dropdown />
+    {/if}
+  </nav>
+{/if}
 
 <style>
-  header .heading {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1em;
-    position: relative;
-  }
+/* --- stories variant --- */
+.stories-header .heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1em;
+  position: relative;
+}
 
-  header .heading > h1 {
-    position: absolute;
-    left: 50%;
-    font-size: 1.7em;
-    transform: translateX(-50%);
-  }
+.stories-header .heading > h1 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.7em;
+}
+
+/* --- languages variant --- */
+.navigation {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  width: 100%;
+}
+
+.navigation > a {
+  align-self: start;
+}
+
+h1 {
+  margin-bottom: 1em;
+  text-align: center;
+  width: 100%;
+}
+
+/* --- cancelled variant --- */
+.go-back-btn{
+  z-index: 10;
+}
+
+.playlist-nav {
+  max-width: 31.25em;
+  width: 100%;
+  flex-wrap: wrap;
+  padding: var(--space-md);
+  position: absolute;
+  margin-top: 2em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#cancelled {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-bottom: 1em;
+}
+
+#cancelled .go-back-btn {
+  display: inline-flex;
+  align-items: center;
+}
+
+p {
+  text-align: center;
+  margin-bottom: 2.5em;
+  width: 100%;
+} 
 </style>
+

--- a/src/lib/components/core/LanguageList.svelte
+++ b/src/lib/components/core/LanguageList.svelte
@@ -53,6 +53,7 @@
     background-color: hsla(197, 38%, 72%, 1);
     height: 1px;
     width: 100%;
+    max-width: 31.25em;
   }
 
   ul {
@@ -63,6 +64,7 @@
     overflow-y: auto;
     margin-bottom: 1em;
     flex-grow: 1;
+    max-width: 31.25em;
   }
 
   li.languages {

--- a/src/lib/components/core/PlaylistHeader.svelte
+++ b/src/lib/components/core/PlaylistHeader.svelte
@@ -4,12 +4,7 @@
 </script>
 
 <header>
-  <!-- <nav id="cancelled">
-    <a href="/lessons" aria-label="go back" class="go-back-btn"><Back /></a>
-    <Dropdown />
-  </nav> -->
   <Heading variant= playlist/>
-
   <picture class="playlist-image-container">
     <source srcset="{playlist.image}?width=448&format=avif" type="image/avif" />
     <source srcset="{playlist.image}?width=448&format=webp" type="image/webp" />
@@ -26,8 +21,6 @@
 </header>
 
 <style>
-
-
 
 .playlist-image-container {
   z-index: 0;

--- a/src/lib/components/core/PlaylistHeader.svelte
+++ b/src/lib/components/core/PlaylistHeader.svelte
@@ -1,13 +1,14 @@
 <script>
-  import { Back, Dropdown } from '$lib/index';
+  import { Heading } from '$lib/index';
   export let playlist;
 </script>
 
 <header>
-  <nav id="cancelled">
+  <!-- <nav id="cancelled">
     <a href="/lessons" aria-label="go back" class="go-back-btn"><Back /></a>
     <Dropdown />
-  </nav>
+  </nav> -->
+  <Heading variant= playlist/>
 
   <picture class="playlist-image-container">
     <source srcset="{playlist.image}?width=448&format=avif" type="image/avif" />
@@ -26,21 +27,7 @@
 
 <style>
 
-.go-back-btn{
-  z-index: 10;
-}
 
-nav {
-  max-width: 31.25em;
-  width: 100%;
-  flex-wrap: wrap;
-  padding: var(--space-md);
-  position: absolute;
-  margin-top: 2em;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
 
 .playlist-image-container {
   z-index: 0;

--- a/src/lib/components/core/PlaylistLike.svelte
+++ b/src/lib/components/core/PlaylistLike.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { OwnPlaylists, LikedPlaylists, SuggestedPlaylists } from '$lib/index';
+  export let data;
+
+  function handleLikeToggle(event) {
+    const { playlistId, isLiked } = event.detail;
+    data.playlists = data.playlists.map(playlist =>
+      playlist.id === playlistId
+        ? { ...playlist, isLiked }
+        : playlist
+    );
+  }
+</script>
+
+<OwnPlaylists {data} on:likeToggle={handleLikeToggle} />
+<LikedPlaylists {data} on:likeToggle={handleLikeToggle} />
+<SuggestedPlaylists {data} on:likeToggle={handleLikeToggle} />

--- a/src/lib/components/forms/Search.svelte
+++ b/src/lib/components/forms/Search.svelte
@@ -42,7 +42,6 @@
 .search-container {
     width: 100%;
     max-width: 31.25em;
-    margin: auto;
     contain: inline-size;
 }
 
@@ -54,7 +53,6 @@
     border-radius: .5em;
     border: none;
     width: 100%;
-    max-width: 31.25em;
     margin: .6em auto;
     box-sizing: border-box;
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -32,6 +32,7 @@ export { default as DeleteDialog } from '$lib/components/core/DeleteDialog.svelt
 export { default as PlaylistHeader } from '$lib/components/core/PlaylistHeader.svelte'
 export { default as PlaylistMeta } from '$lib/components/core/PlaylistMeta.svelte'
 export { default as PlaylistStories } from '$lib/components/core/PlaylistStories.svelte'
+export { default as PlaylistLike } from '$lib/components/core/PlaylistLike.svelte'
 
 export { default as Button } from '$lib/components/forms/ContinueBtn.svelte'
 export { default as Filter } from '$lib/components/forms/Filter.svelte'

--- a/src/routes/all-stories/+page.svelte
+++ b/src/routes/all-stories/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <main>
-  <Heading />
+  <Heading variant="stories" />
   <AllStoriesFilter 
     {seasons} 
     {languages} 

--- a/src/routes/languages/+page.svelte
+++ b/src/routes/languages/+page.svelte
@@ -9,10 +9,7 @@
 <main>
   <section>
     <Heading variant= languages />
-
-   
     <LanguageList {data} />
-
     <Button type="input" variant="secondary" />
   </section>
 </main>
@@ -37,23 +34,5 @@
     padding: 1.25em;
     position: relative;
   }
-
-  .navigation {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-    width: 100%;
-  }
-
-  .navigation > a {
-    align-self: start;
-  }
-
-  h1 {
-    margin-bottom: 1em;
-    text-align: center;
-    width: 100%;
-  }
-
 
 </style>

--- a/src/routes/languages/+page.svelte
+++ b/src/routes/languages/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Back, Button, LanguageList } from '$lib/index';
+  import { Heading, Button, LanguageList } from '$lib/index';
 
   export let data = {
     languages: []
@@ -8,18 +8,9 @@
 
 <main>
   <section>
-    <nav class="navigation">
-      <a href="/onboarding" aria-label="Go back to onboarding">
-        <Back color="white" />
-      </a>
-      <h1>We are going to learn!</h1>
-    </nav>
+    <Heading variant= languages />
 
-    <p>
-      Now it is time to pick the language(s) your child will learn.
-      You can pick a <strong>maximum of 3</strong> languages.
-    </p>
-
+   
     <LanguageList {data} />
 
     <Button type="input" variant="secondary" />
@@ -64,9 +55,5 @@
     width: 100%;
   }
 
-  p {
-    text-align: center;
-    margin-bottom: 2.5em;
-    width: 100%;
-  }
+
 </style>

--- a/src/routes/languages/+page.svelte
+++ b/src/routes/languages/+page.svelte
@@ -23,6 +23,8 @@
     height: 100dvh;
     color: var(--color-white);
     overflow: hidden;
+    display: flex;
+    justify-content: center;
   }
 
   section {
@@ -33,6 +35,7 @@
     align-items: center;
     padding: 1.25em;
     position: relative;
+    max-width: 31.25em;
   }
 
 </style>

--- a/src/routes/languages/+page.svelte
+++ b/src/routes/languages/+page.svelte
@@ -7,35 +7,27 @@
 </script>
 
 <main>
-  <section>
-    <Heading variant= languages />
-    <LanguageList {data} />
-    <Button type="input" variant="secondary" />
-  </section>
+  <Heading variant= languages />
+  <LanguageList {data} />
+  <Button type="input" variant="secondary" />
 </main>
 
 <style>
-  main {
-    background: var(--bg-image-blue);
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: bottom;
-    height: 100dvh;
-    color: var(--color-white);
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-  }
-
-  section {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 100dvh;
-    align-items: center;
-    padding: 1.25em;
-    position: relative;
-    max-width: 31.25em;
-  }
+  
+main {
+  background: var(--bg-image-blue);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: bottom;
+  height: 100dvh;
+  color: var(--color-white);
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.25em;
+  position: relative;
+}
 
 </style>

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -1,19 +1,11 @@
 <script>
-  import { Menu, MakePlaylist, OwnPlaylists, AllStories, LikedPlaylists, SuggestedPlaylists   } from '$lib/index';
+  import { Menu, MakePlaylist, AllStories, PlaylistLike   } from '$lib/index';
 
   let currentPage = "lessons";
 
   /** @type {import('./$types').PageData} */
   export let data;
 
-  function handleLikeToggle(event) {
-    const { playlistId, isLiked } = event.detail;
-    data.playlists = data.playlists.map(playlist =>
-      playlist.id === playlistId
-        ? { ...playlist, isLiked: isLiked }
-        : playlist
-    );
-  }
 </script>
 
 <main>
@@ -26,39 +18,38 @@
     </ul>
   </header>
 
-  <OwnPlaylists {data} on:likeToggle={handleLikeToggle} />
+  <!-- {PLaylistLike} includes {Own playlists, Liked playlist & Suggested playlists} -->
+  <PlaylistLike {data} />
   <MakePlaylist {data} />
   <AllStories {data} />
-  <LikedPlaylists {data} on:likeToggle={handleLikeToggle} />
-  <SuggestedPlaylists {data} on:likeToggle={handleLikeToggle} />
 </main>
 
 <style>
 
-  main {
-    height: 100%;
-    color: var(--color-text-light);
-    background-image: var(--bg-image-purple);
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 5em;
-  }
+main {
+  height: 100%;
+  color: var(--color-text-light);
+  background-image: var(--bg-image-purple);
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 5em;
+}
 
-  header {
-    margin-bottom: var(--space-lg);
-    display: flex;
-    flex-direction: column;
+header {
+  margin-bottom: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+h1 {
+  margin-top: var(--space-lg);
+  margin-bottom: var(--space-md);
+}
+
+@media (min-width: 600px) {
+  main {
     align-items: center;
   }
-
-  h1 {
-    margin-top: var(--space-lg);
-    margin-bottom: var(--space-md);
-  }
-
-  @media (min-width: 600px) {
-    main {
-      align-items: center;
-    }
-  }
+}
 </style>


### PR DESCRIPTION
## What does this change?

This PR fixes the following:

- Moves all functions that were still in the main page.svelte of the page to their own component. 
- Styling issues with languages page
- Makes the Heading.svelte component more dynamic which leads to the code being more DRY.

Resolves issue #363 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

### Heading.svelte
<img width="667" height="843" alt="image" src="https://github.com/user-attachments/assets/836ee1de-c869-4f2a-bb8b-6a19d63e109b" />

### Languages before
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/9d564696-99b0-48a7-8da5-09a3e073430c" />

### Languages after
<img width="1917" height="968" alt="image" src="https://github.com/user-attachments/assets/95800720-ff8e-4d59-b3cb-5f251de79962" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
- Verify if components work
- If code is readable
- If languages page styling is good
